### PR TITLE
Add UMD, node and npm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/backbone-collection-search-ajax.js
+++ b/backbone-collection-search-ajax.js
@@ -3,7 +3,17 @@
 //     For all details and documentation:
 //     https://github.com/homeslicesolutions/backbone-collection-search
 
-!function(_, Backbone){
+;(function (root, factory) {
+
+  if (typeof define === 'function' && define.amd) {
+    define(['underscore', 'backbone'], factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory(require('underscore'), require('backbone'));
+  } else {
+    factory(root._, root.Backbone);
+  }
+
+}(this, function (_, Backbone) {
 
   // Extending out
   _.extend(Backbone.Collection.prototype, {  
@@ -57,4 +67,6 @@
 
   });
 
-}(_, Backbone);
+  return Backbone;
+
+}));

--- a/backbone-collection-search.js
+++ b/backbone-collection-search.js
@@ -3,7 +3,17 @@
 //     For all details and documentation:
 //     https://github.com/homeslicesolutions/backbone-collection-search
 
-!function(_, Backbone){
+;(function (root, factory) {
+
+  if (typeof define === 'function' && define.amd) {
+    define(['underscore', 'backbone'], factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory(require('underscore'), require('backbone'));
+  } else {
+    factory(root._, root.Backbone);
+  }
+
+}(this, function (_, Backbone) {
 
   // Extending out
   _.extend(Backbone.Collection.prototype, {  
@@ -73,4 +83,6 @@
 
   });
 
-}(_, Backbone);
+  return Backbone;
+
+}));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "backbone-collection-search",
+  "version": "0.2.1",
+  "description": "A keyword search plugin for Backbone.Collections",
+  "main": "backbone-collection-search.js",
+  "directories": {
+    "test": "tests"
+  },
+  "repository": "homeslicesolutions/backbone-collection-search",
+  "keywords": ["backbone"],
+  "author": "Joe Vu",
+  "license": "MIT",
+  "dependencies": {
+    "backbone": "^1.0.0",
+    "underscore": "^1.6.0"
+  }
+}


### PR DESCRIPTION
This adds a umd wrapper so the module can be loaded with commonjs module bundlers like browserify and webpack, as well as amd loaders. This also lets the module work in node (which it does just fine since it doesn't depend on jquery directly!)
